### PR TITLE
Enable null state analysis

### DIFF
--- a/Commands/InitCommand.cs
+++ b/Commands/InitCommand.cs
@@ -10,7 +10,7 @@ namespace ThunderstoreCLI.Commands
         {
             var path = config.GetProjectConfigPath();
             var projectDir = Path.GetDirectoryName(path);
-            if (!Directory.Exists(projectDir))
+            if (projectDir is not null && !Directory.Exists(projectDir))
             {
                 Console.WriteLine($"Creating directory {projectDir}");
                 Directory.CreateDirectory(projectDir);

--- a/Config/CLIParameterConfig.cs
+++ b/Config/CLIParameterConfig.cs
@@ -20,7 +20,7 @@ namespace ThunderstoreCLI.Config
             };
         }
 
-        public override PackageMeta GetPackageMeta()
+        public override PackageMeta? GetPackageMeta()
         {
             if (options == null) return null;
             return new PackageMeta()

--- a/Config/Config.cs
+++ b/Config/Config.cs
@@ -1,4 +1,5 @@
-﻿using System.Collections.Generic;
+﻿using System;
+using System.Collections.Generic;
 using System.IO;
 using System.Net.Http.Headers;
 
@@ -21,7 +22,7 @@ namespace ThunderstoreCLI.Config
             AuthConfig = authConfig;
         }
 
-        public string GetProjectBasePath()
+        public string? GetProjectBasePath()
         {
             return Path.GetDirectoryName(GetProjectConfigPath());
         }
@@ -33,21 +34,33 @@ namespace ThunderstoreCLI.Config
 
         public string GetPackageIconPath()
         {
+            if (BuildConfig.IconPath is null) {
+                throw new Exception("BuildConfig.IconPath can't be null");
+            }
             return GetProjectRelativePath(BuildConfig.IconPath);
         }
 
         public string GetPackageReadmePath()
         {
+            if (BuildConfig.ReadmePath is null) {
+                throw new Exception("BuildConfig.ReadmePath can't be null");
+            }
             return GetProjectRelativePath(BuildConfig.ReadmePath);
         }
 
         public string GetProjectConfigPath()
         {
+            if (GeneralConfig.ProjectConfigPath is null) {
+                throw new Exception("GeneralConfig.ProjectConfigPath can't be null");
+            }
             return Path.GetFullPath(GeneralConfig.ProjectConfigPath);
         }
 
         public string GetBuildOutputDir()
         {
+            if (BuildConfig.OutDir is null) {
+                throw new Exception("BuildConfig.OutDir can't be null");
+            }
             return GetProjectRelativePath(BuildConfig.OutDir);
         }
 
@@ -63,6 +76,9 @@ namespace ThunderstoreCLI.Config
 
         public string GetRepositoryBaseUrl()
         {
+            if (PublishConfig.Repository is null) {
+                throw new Exception("PublishConfig.Repository can't be null");
+            }
             var repo = PublishConfig.Repository.TrimEnd('/');
             return $"{repo}/api/experimental/";
         }
@@ -135,18 +151,18 @@ namespace ThunderstoreCLI.Config
 
     public class GeneralConfig
     {
-        public string ProjectConfigPath { get; set; }
+        public string? ProjectConfigPath { get; set; }
     }
 
     public class PackageMeta
     {
-        public string Namespace { get; set; }
-        public string Name { get; set; }
-        public string VersionNumber { get; set; }
-        public string Description { get; set; }
-        public string WebsiteUrl { get; set; }
+        public string? Namespace { get; set; }
+        public string? Name { get; set; }
+        public string? VersionNumber { get; set; }
+        public string? Description { get; set; }
+        public string? WebsiteUrl { get; set; }
         public bool? ContainsNsfwContent { get; set; }
-        public Dictionary<string, string> Dependencies { get; set; }
+        public Dictionary<string, string>? Dependencies { get; set; }
     }
 
     public struct CopyPathMap
@@ -163,23 +179,23 @@ namespace ThunderstoreCLI.Config
 
     public class BuildConfig
     {
-        public string IconPath { get; set; }
-        public string ReadmePath { get; set; }
-        public string OutDir { get; set; }
-        public List<CopyPathMap> CopyPaths { get; set; }
+        public string? IconPath { get; set; }
+        public string? ReadmePath { get; set; }
+        public string? OutDir { get; set; }
+        public List<CopyPathMap>? CopyPaths { get; set; }
     }
 
     public class PublishConfig
     {
-        public string Repository { get; set; }
-        public string[] Communities { get; set; }
-        public string[] Categories { get; set; }
+        public string? Repository { get; set; }
+        public string[]? Communities { get; set; }
+        public string[]? Categories { get; set; }
     }
 
     public class AuthConfig
     {
-        public string DefaultToken { get; set; }
-        public Dictionary<string, string> AuthorTokens { get; set; }
+        public string? DefaultToken { get; set; }
+        public Dictionary<string, string>? AuthorTokens { get; set; }
         public bool? UseSessionAuth { get; set; }
     }
 }

--- a/Config/EmptyConfig.cs
+++ b/Config/EmptyConfig.cs
@@ -3,27 +3,27 @@
     public abstract class EmptyConfig : IConfigProvider
     {
         public virtual void Parse(Config currentConfig) { }
-        public virtual GeneralConfig GetGeneralConfig()
+        public virtual GeneralConfig? GetGeneralConfig()
         {
             return null;
         }
 
-        public virtual PackageMeta GetPackageMeta()
+        public virtual PackageMeta? GetPackageMeta()
         {
             return null;
         }
 
-        public virtual BuildConfig GetBuildConfig()
+        public virtual BuildConfig? GetBuildConfig()
         {
             return null;
         }
 
-        public virtual PublishConfig GetPublishConfig()
+        public virtual PublishConfig? GetPublishConfig()
         {
             return null;
         }
 
-        public virtual AuthConfig GetAuthConfig()
+        public virtual AuthConfig? GetAuthConfig()
         {
             return null;
         }

--- a/Config/IConfigProvider.cs
+++ b/Config/IConfigProvider.cs
@@ -4,10 +4,10 @@
     {
         void Parse(Config currentConfig);
 
-        GeneralConfig GetGeneralConfig();
-        PackageMeta GetPackageMeta();
-        BuildConfig GetBuildConfig();
-        PublishConfig GetPublishConfig();
-        AuthConfig GetAuthConfig();
+        GeneralConfig? GetGeneralConfig();
+        PackageMeta? GetPackageMeta();
+        BuildConfig? GetBuildConfig();
+        PublishConfig? GetPublishConfig();
+        AuthConfig? GetAuthConfig();
     }
 }

--- a/Config/UserFileConfig.cs
+++ b/Config/UserFileConfig.cs
@@ -2,7 +2,7 @@
 {
     class UserFileConfig : EmptyConfig
     {
-        private AuthConfig authConfig;
+        private AuthConfig? authConfig;
 
         public override void Parse(Config currentConfig)
         {

--- a/PackageManifestV1.cs
+++ b/PackageManifestV1.cs
@@ -5,21 +5,21 @@ namespace ThunderstoreCLI
     public class PackageManifestV1
     {
         [JsonPropertyName("namespace")]
-        public string Namespace { get; set; }
+        public string? Namespace { get; set; }
 
         [JsonPropertyName("name")]
-        public string Name { get; set; }
+        public string? Name { get; set; }
 
         [JsonPropertyName("description")]
-        public string Description { get; set; }
+        public string? Description { get; set; }
 
         [JsonPropertyName("version_number")]
-        public string VersionNumber { get; set; }
+        public string? VersionNumber { get; set; }
 
         [JsonPropertyName("dependencies")]
-        public string[] Dependencies { get; set; }
+        public string[]? Dependencies { get; set; }
 
         [JsonPropertyName("website_url")]
-        public string WebsiteUrl { get; set; }
+        public string? WebsiteUrl { get; set; }
     }
 }

--- a/Program.cs
+++ b/Program.cs
@@ -8,16 +8,16 @@ namespace ThunderstoreCLI
     public class PackageOptions
     {
         [Option("config-path", Required = false, Default = Defaults.PROJECT_CONFIG_PATH, HelpText = "Path for the project configuration file")]
-        public string ConfigPath { get; set; }
+        public string? ConfigPath { get; set; }
 
         [Option("package-name", SetName = "build", Required = false, HelpText = "Name for the package")]
-        public string Name { get; set; }
+        public string? Name { get; set; }
 
         [Option("package-namespace", SetName = "build", Required = false, HelpText = "Namespace for the package")]
-        public string Namespace { get; set; }
+        public string? Namespace { get; set; }
 
         [Option("package-version", SetName = "build", Required = false, HelpText = "Version number for the package")]
-        public string VersionNumber { get; set; }
+        public string? VersionNumber { get; set; }
     }
 
     [Verb("init", HelpText = "Initialize a new project configuration")]
@@ -36,13 +36,13 @@ namespace ThunderstoreCLI
     public class PublishOptions : PackageOptions
     {
         [Option("file", SetName = "select", Required = false, HelpText = "If provided, use defined package instead of building.")]
-        public string File { get; set; }
+        public string? File { get; set; }
 
         [Option("token", Required = false, HelpText = "Authentication token to use for publishing.")]
-        public string Token { get; set; }
+        public string? Token { get; set; }
 
         [Option("repository", Required = false, HelpText = "URL of the repository where to publish.")]
-        public string Repository { get; set; }
+        public string? Repository { get; set; }
 
         [Option("use-session-auth", Default = false, Required = false, HelpText = "Use session auth instead of bearer auth.\nDEPRECATED: will be removed in the future without warning!")]
         public bool UseSessionAuth { get; set; }

--- a/ThunderstoreCLI.csproj
+++ b/ThunderstoreCLI.csproj
@@ -17,6 +17,7 @@
         <SelfContained>true</SelfContained>
         <PublishReadyToRun>true</PublishReadyToRun>
         <IncludeNativeLibrariesForSelfExtract>true</IncludeNativeLibrariesForSelfExtract>
+        <Nullable>enable</Nullable>
     </PropertyGroup>
 
     <ItemGroup>

--- a/Utils/TomlUtils.cs
+++ b/Utils/TomlUtils.cs
@@ -44,11 +44,12 @@ namespace ThunderstoreCLI
             }
         }
 
-        public static string SafegetString(TomlNode node, string key)
+        public static string? SafegetString(TomlNode parentNode, string key)
         {
             try
             {
-                return node[key];
+                var textNode = parentNode[key];
+                return textNode.IsString ? textNode.ToString() : null;
             }
             catch (NullReferenceException)
             {
@@ -56,11 +57,12 @@ namespace ThunderstoreCLI
             }
         }
 
-        public static bool? SafegetBool(TomlNode node, string key)
+        public static bool? SafegetBool(TomlNode parentNode, string key)
         {
             try
             {
-                return node[key];
+                var boolNode = parentNode[key];
+                return boolNode.IsBoolean ? boolNode : null;
             }
             catch (NullReferenceException)
             {
@@ -68,7 +70,6 @@ namespace ThunderstoreCLI
             }
         }
 
-        #nullable enable
         public static string[]? SafegetArray(TomlNode node, string key, string[]? defaultValue = null)
         {
             try
@@ -80,7 +81,6 @@ namespace ThunderstoreCLI
                 return defaultValue;
             }
         }
-        #nullable disable
 
         public static TomlArray FromArray(string[] array)
         {


### PR DESCRIPTION
Adjust code that causes the analysis to emit warnings to check
variables for null values before using them.

In this version, checks for values provided by the config system are
checked just before they are used. In the cases where a fallback value
can't be used, the program crashes. To avoid crashes in the middle of
running commands that e.g. writes files, we might want to prevalidate
the config before running the commands in the future.