### PR TITLE
Rename and modify SafegetArray helper method

### DIFF
--- a/Config/ProjectFileConfig.cs
+++ b/Config/ProjectFileConfig.cs
@@ -121,8 +121,8 @@ namespace ThunderstoreCLI.Config
             return new PublishConfig
             {
                 Repository = TomlUtils.SafegetString(publishConfig, "repository"),
-                Communities = TomlUtils.SafegetArray(publishConfig, "communities", Array.Empty<string>()),
-                Categories = TomlUtils.SafegetArray(publishConfig, "categories", Array.Empty<string>())
+                Communities = TomlUtils.SafegetStringArray(publishConfig, "communities", Array.Empty<string>()),
+                Categories = TomlUtils.SafegetStringArray(publishConfig, "categories", Array.Empty<string>())
             };
         }
 

--- a/Utils/TomlUtils.cs
+++ b/Utils/TomlUtils.cs
@@ -70,11 +70,14 @@ namespace ThunderstoreCLI
             }
         }
 
-        public static string[]? SafegetArray(TomlNode node, string key, string[]? defaultValue = null)
+        public static string[]? SafegetStringArray(TomlNode parentNode, string key, string[]? defaultValue = null)
         {
             try
             {
-                return node[key].AsArray.RawArray.Select(x => x.AsString.Value).ToArray();
+                var arrayNode = parentNode[key];
+                return arrayNode.IsArray
+                    ? arrayNode.AsArray.RawArray.Select(x => x.AsString.Value).ToArray()
+                    : defaultValue;
             }
             catch (NullReferenceException)
             {


### PR DESCRIPTION
* Call it SafegetStringArray to be more precise
* Rename parameter to parentNode and change the implementation a bit to
  be concistent with other similar helper methods