### PR TITLE
Show notification if newer version has been released

### DIFF
--- a/Defaults.cs
+++ b/Defaults.cs
@@ -2,6 +2,8 @@ namespace ThunderstoreCLI
 {
     public static class Defaults
     {
+        public const string GITHUB_REPO = "thunderstore-cli";
+        public const string GITHUB_USER = "thunderstore-io";
         public const string PROJECT_CONFIG_PATH = "./thunderstore.toml";
         public const string REPOSITORY_URL = "https://thunderstore.io";
     }

--- a/Program.cs
+++ b/Program.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Collections.Generic;
+using System.Threading.Tasks;
 using CommandLine;
 using ThunderstoreCLI.Commands;
 using ThunderstoreCLI.Options;
@@ -36,17 +37,69 @@ namespace ThunderstoreCLI
 
         static int Init(InitOptions options)
         {
-            return InitCommand.Run(GetConfig(new Config.CLIInitCommandConfig(options)));
+            var updateChecker = CheckForUpdates();
+            var exitCode = InitCommand.Run(GetConfig(new Config.CLIInitCommandConfig(options)));
+            WriteUpdateNotification(updateChecker);
+            return exitCode;
         }
 
         static int Build(BuildOptions options)
         {
-            return BuildCommand.Run(GetConfig(new Config.CLIBuildCommandConfig(options)));
+            var updateChecker = CheckForUpdates();
+            var exitCode = BuildCommand.Run(GetConfig(new Config.CLIBuildCommandConfig(options)));
+            WriteUpdateNotification(updateChecker);
+            return exitCode;
         }
 
         static int Publish(PublishOptions options)
         {
-            return PublishCommand.Run(GetConfig(new Config.CLIPublishCommandConfig(options)));
+            var updateChecker = CheckForUpdates();
+            var exitCode = PublishCommand.Run(GetConfig(new Config.CLIPublishCommandConfig(options)));
+            WriteUpdateNotification(updateChecker);
+            return exitCode;
+        }
+
+        private static async Task<string> CheckForUpdates()
+        {
+            var current = MiscUtils.GetCurrentVersion();
+            int[] latest;
+
+            try
+            {
+                var responseContent = await MiscUtils.FetchReleaseInformation();
+                latest = MiscUtils.ParseLatestVersion(responseContent);
+            }
+            catch (Exception)
+            {
+                return "";
+            }
+
+            if (
+                latest[0] > current[0] ||
+                (latest[0] == current[0] && latest[1] > current[1]) ||
+                (latest[0] == current[0] && latest[1] == current[1] && latest[2] > current[2])
+            )
+            {
+                var version = $"{latest[0]}.{latest[1]}.{latest[2]}";
+                return $"Newer version {version} of Thunderstore CLI is available";
+            }
+
+            return "";
+        }
+
+        private static void WriteUpdateNotification(Task<string> checkTask)
+        {
+            if (!checkTask.IsCompleted)
+            {
+                return;
+            }
+
+            var notification = checkTask.GetAwaiter().GetResult();
+
+            if (notification != "")
+            {
+                Write.Note(notification);
+            }
         }
     }
 

--- a/README.md
+++ b/README.md
@@ -13,3 +13,17 @@ with:
 ```
 dotnet tool install -g dotnet-format
 ```
+
+## Versioning
+
+This project uses [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+Versioning is handled with [MinVer](https://github.com/adamralph/minver) via Git
+tags.
+
+* To create a new pre-release, use alpha suffix, e.g. `git tag 0.1.0-alpha.1`
+* Any subsequent commits will automatically be versioned "0.1.0-alpha.1.1",
+  where the last number denotes the number of commits since the last version tag
+  (a.k.a. "height")
+* To create a new release, use e.g. `git tag 0.1.0`
+* Any subsequent commits will automatically be versioned "0.1.1-alpha.0.1"
+* Remember to push the tags to GitHub, e.g. `git push origin 0.1.0`

--- a/ThunderstoreCLI.csproj
+++ b/ThunderstoreCLI.csproj
@@ -6,7 +6,6 @@
         <RootNamespace>ThunderstoreCLI</RootNamespace>
         <AssemblyName>tcli</AssemblyName>
         <StartupObject>ThunderstoreCLI.Program</StartupObject>
-        <Version>0.0.1</Version>
         <Company>Thunderstore</Company>
         <Product>Thunderstore CLI</Product>
         <PackageProjectUrl>https://thunderstore.io/</PackageProjectUrl>
@@ -23,6 +22,10 @@
     <ItemGroup>
         <PackageReference Include="CommandLineParser" Version="2.8.0" />
         <PackageReference Include="Crayon" Version="2.0.60" />
+        <PackageReference Include="MinVer" Version="2.5.0">
+          <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+          <PrivateAssets>all</PrivateAssets>
+        </PackageReference>
         <PackageReference Include="Tommy" Version="3.0.1" />
     </ItemGroup>
 

--- a/Utils/Comparers.cs
+++ b/Utils/Comparers.cs
@@ -1,0 +1,39 @@
+using System.Collections.Generic;
+
+namespace ThunderstoreCLI.Comparers
+{
+    public class SemVer : IComparer<int[]>
+    {
+        /// <summary>Compare two int arrays containing SemVer parts</summary>
+        /// <remarks>Each parameter should have length of 3</remarks>
+        public int Compare(int[]? a, int[]? b)
+        {
+            // IComparer forces us to accept nullable parameters, even
+            // though in this case they make no sense.
+            if (a is null && b is null)
+            {
+                return 0;
+            }
+            else if (a is null)
+            {
+                return -1;
+            }
+            else if (b is null)
+            {
+                return 1;
+            }
+
+            if (a[0] != b[0])
+            {
+                return a[0].CompareTo(b[0]);
+            }
+
+            if (a[1] != b[1])
+            {
+                return a[1].CompareTo(b[1]);
+            }
+
+            return a[2].CompareTo(b[2]);
+        }
+    }
+}

--- a/Utils/MiscUtils.cs
+++ b/Utils/MiscUtils.cs
@@ -1,0 +1,76 @@
+using System;
+using System.Linq;
+using System.Net.Http;
+using System.Reflection;
+using System.Text.RegularExpressions;
+using System.Threading.Tasks;
+
+namespace ThunderstoreCLI
+{
+    public static class MiscUtils
+    {
+        /// <summary>Return application version</summary>
+        /// Version number is controlled via MinVer by creating new tags
+        /// in git. See README for more information.
+        public static int[] GetCurrentVersion()
+        {
+            string version;
+
+            try
+            {
+                version = Assembly.GetEntryAssembly()!
+                    .GetCustomAttribute<AssemblyInformationalVersionAttribute>()!
+                    .InformationalVersion;
+            }
+            catch (NullReferenceException)
+            {
+                throw new Exception("Reading app version from assembly failed");
+            }
+
+            // Drop possible pre-release cruft ("-alpha.0.1") from the end.
+            var versionParts = version.Split('-')[0].Split('.');
+
+            if (versionParts is null || versionParts.Length != 3)
+            {
+                throw new Exception("Malformed app version: ${version}");
+            }
+
+            return versionParts.Select(part => Int32.Parse(part)).ToArray();
+        }
+
+        /// <summary>Extract version from release information</summary>
+        /// <exception cref="ArgumentException">Throw if version number not found</exception>
+        public static int[] ParseLatestVersion(string releaseJsonData)
+        {
+            var regex = new Regex(@"""tag_name"":""(\d+.\d+.\d+)""");
+            MatchCollection matches = regex.Matches(releaseJsonData);
+
+            if (matches.Count == 0)
+            {
+                throw new ArgumentException("Response didn't contain a valid release value");
+            }
+
+            return matches
+                .Select(match => match.Groups[1].ToString().Split('.'))
+                .Select(ver => ver.Select(part => Int32.Parse(part)).ToArray())
+                .OrderByDescending(ver => ver, new Comparers.SemVer())
+                .First();
+        }
+
+        /// <summary>Read information about releases from GitHub</summary>
+        /// <exception cref="HttpRequestException">Throw for non-success status code</exception>
+        /// <exception cref="TaskCanceledException">Throw if request timeouts</exception>
+        public static async Task<string> FetchReleaseInformation()
+        {
+            using var client = new HttpClient();
+            client.DefaultRequestHeaders.Add("Accept", "application/vnd.github.v3+json");
+            client.DefaultRequestHeaders.Add("User-Agent", Defaults.GITHUB_USER);
+
+            var url = $"https://api.github.com/repos/{Defaults.GITHUB_USER}/{Defaults.GITHUB_REPO}/releases";
+            var response = await client.GetAsync(url);
+            response.EnsureSuccessStatusCode();
+
+            return await response.Content.ReadAsStringAsync();
+        }
+    }
+}


### PR DESCRIPTION
Release information is read from GitHub repo. To avoid slowing the
usage of the CLI too much, the request timeouts after three seconds.

The version number is read from the JSON response with regex to avoid
JSON deserialization. This requires that the release versions follow
the X.Y.Z semantic versioning.

In case of errors while reading the version of the latest release, the
method fails silently, since it's unlikely that the end user would be
interested in any error messages regarding these issues.

The version number of currently installed app is read from .csproj
file, meaning that the version number must be manually updated in the
code whenever a new version is released.