### PR TITLE
Remove pre-commit hook that prevented commiting to master branch

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -12,8 +12,6 @@ repos:
     -   id: end-of-file-fixer
     -   id: mixed-line-ending
         args: [--fix=lf]
-    -   id: no-commit-to-branch
-        args: [--branch, master]
     -   id: trailing-whitespace
 -   repo: local
     hooks:


### PR DESCRIPTION
While it's nice to have this on locally to protect one from
accidentally committing directly to master, it causes CI checks to fail
when merge commits are generated on GitHub.