### PR TITLE
Move to .NET 6

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -46,7 +46,7 @@ jobs:
       - uses: actions/checkout@v2
       - uses: actions/setup-dotnet@v1
         with:
-          dotnet-version: '5.0.x'
+          dotnet-version: '6.0.x'
       - id: tag
         uses: dawidd6/action-get-tag@v1
       - name: Install dependencies

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -10,7 +10,7 @@ jobs:
       - uses: actions/checkout@v2
       - uses: actions/setup-dotnet@v1
         with:
-          dotnet-version: '5.0.x'
+          dotnet-version: '6.0.x'
       - uses: actions/setup-python@v2
         with:
           python-version: '3.8'
@@ -33,7 +33,7 @@ jobs:
       - uses: actions/checkout@v2
       - uses: actions/setup-dotnet@v1
         with:
-          dotnet-version: '5.0.x'
+          dotnet-version: '6.0.x'
       - name: Install dependencies
         run: dotnet restore
       - name: Build

--- a/ThunderstoreCLI.Tests/ThunderstoreCLI.Tests.csproj
+++ b/ThunderstoreCLI.Tests/ThunderstoreCLI.Tests.csproj
@@ -1,9 +1,10 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
     <PropertyGroup>
-        <TargetFramework>net5.0</TargetFramework>
+        <TargetFramework>net6.0</TargetFramework>
         <IsPackable>false</IsPackable>
         <RuntimeIdentifier>win-x64</RuntimeIdentifier>
+        <LangVersion>latest</LangVersion>
     </PropertyGroup>
 
     <ItemGroup>

--- a/ThunderstoreCLI/.editorconfig
+++ b/ThunderstoreCLI/.editorconfig
@@ -1,0 +1,2 @@
+[*.cs]
+dotnet_diagnostic.IL2026.severity = none # disables warning about types missing at runtime due to trimming, repeats for every JsonSerializer call unless we move to using JsonSerializerContext/JsonTypeInfo<T> (maybe after more IDEs get support for .NET 6 features)

--- a/ThunderstoreCLI/ThunderstoreCLI.csproj
+++ b/ThunderstoreCLI/ThunderstoreCLI.csproj
@@ -2,7 +2,7 @@
 
     <PropertyGroup>
         <OutputType>Exe</OutputType>
-        <TargetFramework>net5.0</TargetFramework>
+        <TargetFramework>net6.0</TargetFramework>
         <RootNamespace>ThunderstoreCLI</RootNamespace>
         <AssemblyName>tcli</AssemblyName>
         <StartupObject>ThunderstoreCLI.Program</StartupObject>
@@ -18,6 +18,7 @@
         <IncludeNativeLibrariesForSelfExtract>true</IncludeNativeLibrariesForSelfExtract>
         <Nullable>enable</Nullable>
         <DebugType Condition=" '$(Configuration)' == 'Release' ">None</DebugType>
+        <LangVersion>latest</LangVersion>
     </PropertyGroup>
 
     <ItemGroup>


### PR DESCRIPTION
.NET 6 should be an essentially free performance improvement, along with being an LTS release with support lasting 3 years.

Other than that, the only really interesting new feature here is probably [compile-time JSON parsers](https://devblogs.microsoft.com/dotnet/try-the-new-system-text-json-source-generator/), as it could possibly provide a performance improvement, although it would be minimal since time is mostly spent sending data back and forth, not in serialization.

[static abstract methods in interfaces](https://devblogs.microsoft.com/dotnet/preview-features-in-net-6-generic-math/#static-abstracts-in-interfaces) might also be useful somewhere, but I doubt it would be anything that couldn't be worked around in other ways.

This PR also includes a .editorconfig to disable warning IL2026 globally, which was being spammed on every usage of JsonSerializer due to it's usage of reflection while the project has trimming enabled. Since all the types reflected on here are used anyway this shouldn't be an issue, and I believe this warning is new to .NET 6 since it provides an alternative way to work with JSON. If you would prefer to leave it enabled, feel free to edit remove that file before merging.