### PR TITLE
Compile-time JSON parsing

### DIFF
--- a/ThunderstoreCLI.Tests/Models/BaseJson.cs
+++ b/ThunderstoreCLI.Tests/Models/BaseJson.cs
@@ -1,0 +1,104 @@
+using System;
+using System.Text.Json;
+using System.Text.Json.Serialization;
+using NuGet.Frameworks;
+using ThunderstoreCLI.Models;
+using Xunit;
+
+namespace ThunderstoreCLI.Tests;
+
+public class TestJson : BaseJson<TestJson, TestJsonContext>
+{
+    public class Location
+    {
+        public string address { get; set; }
+    }
+
+    public string name { get; set; }
+    public int age { get; set; }
+    public Location home { get; set; }
+}
+
+[JsonSerializable(typeof(TestJson))]
+public partial class TestJsonContext : JsonSerializerContext { }
+
+public class ThunderstoreCLI_BaseJson
+{
+    [Fact]
+    public void Deserialize_WhenGivenEmpty_ReturnsDefaults()
+    {
+        var test = TestJson.Deserialize("{}");
+
+        Assert.NotNull(test);
+
+        Assert.Null(test.name);
+        Assert.Equal(0, test.age);
+        Assert.Null(test.home);
+    }
+
+    [Fact]
+    public void Deserialize_WhenGivenFilled_ReturnsExpected()
+    {
+        var test = TestJson.Deserialize(@"
+{
+    ""name"": ""john"",
+    ""age"": 24,
+    ""home"": {
+        ""address"": ""123 house street""
+    }
+}"
+        );
+
+        Assert.NotNull(test);
+        Assert.NotNull(test.home);
+
+        Assert.Equal("john", test.name);
+        Assert.Equal(24, test.age);
+        Assert.Equal("123 house street", test.home.address);
+    }
+
+    [Fact]
+    public void Serialize_WhenGivenFilled_ReturnsExpected()
+    {
+        Assert.Equal(
+            @"{""name"":""smith"",""age"":32,""home"":{""address"":""456 business parkway""}}",
+            new TestJson()
+            {
+                name = "smith",
+                age = 32,
+                home = new TestJson.Location()
+                {
+                    address = "456 business parkway"
+                }
+            }.Serialize()
+        );
+    }
+
+    [Fact]
+    public void Serialize_WhenAskedToIndent_Indents()
+    {
+        var options = new JsonSerializerOptions()
+        {
+            WriteIndented = true
+        };
+
+        Assert.Equal(
+            @"{
+  ""name"": ""jason"",
+  ""age"": 19,
+  ""home"": {
+    ""address"": ""nowhere""
+  }
+}",
+            new TestJson()
+            {
+                name = "jason",
+                age = 19,
+                home = new TestJson.Location()
+                {
+                    address = "nowhere"
+                }
+            }.Serialize(options)
+        );
+    }
+}

--- a/ThunderstoreCLI/.editorconfig
+++ b/ThunderstoreCLI/.editorconfig
@@ -1,2 +1,0 @@
-[*.cs]
-dotnet_diagnostic.IL2026.severity = none # disables warning about types missing at runtime due to trimming, repeats for every JsonSerializer call unless we move to using JsonSerializerContext/JsonTypeInfo<T> (maybe after more IDEs get support for .NET 6 features)

--- a/ThunderstoreCLI/Commands/BuildCommand.cs
+++ b/ThunderstoreCLI/Commands/BuildCommand.cs
@@ -298,7 +298,7 @@ public static class BuildCommand
         {
             WriteIndented = true
         };
-        return JsonSerializer.Serialize(manifest, serializerOptions);
+        return manifest.Serialize(serializerOptions);
     }
 
     public static List<string> ValidateConfig(Config.Config config, bool throwIfErrors = true)

--- a/ThunderstoreCLI/Models/BaseJson.cs
+++ b/ThunderstoreCLI/Models/BaseJson.cs
@@ -1,0 +1,29 @@
+using System.Text.Json;
+using System.Text.Json.Serialization;
+using System.Text.Json.Serialization.Metadata;
+
+namespace ThunderstoreCLI.Models;
+
+public abstract class BaseJson<T, Context>
+    where T : BaseJson<T, Context>
+    where Context : JsonSerializerContext
+{
+    public string Serialize(JsonSerializerOptions? options = null)
+    {
+        var context = (Context) Activator.CreateInstance(typeof(Context), options)!;
+
+        return JsonSerializer.Serialize(this, typeof(T), context);
+    }
+    public static T? Deserialize(string json, JsonSerializerOptions? options = null)
+    {
+        var context = (Context) Activator.CreateInstance(typeof(Context), options)!;
+
+        return (T?) JsonSerializer.Deserialize(json, typeof(T), context);
+    }
+    public static T? Deserialize(Stream json, JsonSerializerOptions? options)
+    {
+        var context = (Context) Activator.CreateInstance(typeof(Context), options)!;
+
+        return (T?) JsonSerializer.Deserialize(json, typeof(T), context);
+    }
+}

--- a/ThunderstoreCLI/Models/PublishModels.cs
+++ b/ThunderstoreCLI/Models/PublishModels.cs
@@ -1,0 +1,151 @@
+using System.Diagnostics.CodeAnalysis;
+using System.Text.Json.Serialization;
+
+namespace ThunderstoreCLI.Models;
+
+[ExcludeFromCodeCoverageAttribute]
+public class PackageUploadMetadata : BaseJson<PackageUploadMetadata, PackageUploadMetadataContext>
+{
+    [JsonPropertyName("author_name")] public string? AuthorName { get; set; }
+
+    [JsonPropertyName("categories")] public string[]? Categories { get; set; }
+
+    [JsonPropertyName("communities")] public string[]? Communities { get; set; }
+
+    [JsonPropertyName("has_nsfw_content")] public bool HasNsfwContent { get; set; }
+
+    [JsonPropertyName("upload_uuid")] public string? UploadUUID { get; set; }
+}
+
+[JsonSerializable(typeof(PackageUploadMetadata))]
+[ExcludeFromCodeCoverageAttribute]
+public partial class PackageUploadMetadataContext : JsonSerializerContext { }
+
+[ExcludeFromCodeCoverageAttribute]
+public class UploadInitiateData : BaseJson<UploadInitiateData, UploadInitiateDataContext>
+{
+    public class UserMediaData
+    {
+        [JsonPropertyName("uuid")] public string? UUID { get; set; }
+
+        [JsonPropertyName("filename")] public string? Filename { get; set; }
+
+        [JsonPropertyName("size")] public long Size { get; set; }
+
+        [JsonPropertyName("datetime_created")] public DateTime TimeCreated { get; set; }
+
+        [JsonPropertyName("expiry")] public DateTime? ExpireTime { get; set; }
+
+        [JsonPropertyName("status")] public string? Status { get; set; }
+    }
+
+    public class UploadPartData
+    {
+        [JsonPropertyName("part_number")] public int PartNumber { get; set; }
+
+        [JsonPropertyName("url")] public string? Url { get; set; }
+
+        [JsonPropertyName("offset")] public long Offset { get; set; }
+
+        [JsonPropertyName("length")] public int Length { get; set; }
+    }
+
+    [JsonPropertyName("user_media")] public UserMediaData? Metadata { get; set; }
+
+    [JsonPropertyName("upload_urls")] public UploadPartData[]? UploadUrls { get; set; }
+}
+
+[JsonSerializable(typeof(UploadInitiateData))]
+[ExcludeFromCodeCoverage]
+public partial class UploadInitiateDataContext : JsonSerializerContext { }
+
+[ExcludeFromCodeCoverageAttribute]
+public class FileData : BaseJson<FileData, FileDataContext>
+{
+    [JsonPropertyName("filename")] public string? Filename { get; set; }
+
+    [JsonPropertyName("file_size_bytes")] public long Filesize { get; set; }
+}
+
+[JsonSerializable(typeof(FileData))]
+[ExcludeFromCodeCoverage]
+public partial class FileDataContext : JsonSerializerContext { }
+
+[ExcludeFromCodeCoverageAttribute]
+public class CompletedUpload : BaseJson<CompletedUpload, CompletedUploadContext>
+{
+    public class CompletedPartData
+    {
+        [JsonPropertyName("ETag")] public string? ETag { get; set; }
+
+        [JsonPropertyName("PartNumber")] public int PartNumber { get; set; }
+    }
+
+    [JsonPropertyName("parts")] public CompletedPartData[]? Parts { get; set; }
+}
+
+[JsonSerializable(typeof(CompletedUpload))]
+public partial class CompletedUploadContext : JsonSerializerContext { }
+
+// JSON response structure for publish package request.
+[ExcludeFromCodeCoverageAttribute]
+public class PublishData : BaseJson<PublishData, PublishDataContext>
+{
+    public class AvailableCommunityData
+    {
+        public class CommunityData
+        {
+            [JsonPropertyName("identifier")] public string? Identifier { get; set; }
+
+            [JsonPropertyName("name")] public string? Name { get; set; }
+
+            [JsonPropertyName("discord_url")] public string? DiscordUrl { get; set; }
+
+            [JsonPropertyName("wiki_url")] public object? WikiUrl { get; set; }
+
+            [JsonPropertyName("require_package_listing_approval")]
+            public bool RequirePackageListingApproval { get; set; }
+        }
+
+        [JsonPropertyName("community")] public CommunityData? Community { get; set; }
+
+        [JsonPropertyName("categories")] public List<string>? Categories { get; set; }
+
+        [JsonPropertyName("url")] public string? Url { get; set; }
+    }
+
+    public class PackageVersionData
+    {
+        [JsonPropertyName("namespace")] public string? Namespace { get; set; }
+
+        [JsonPropertyName("name")] public string? Name { get; set; }
+
+        [JsonPropertyName("version_number")] public string? VersionNumber { get; set; }
+
+        [JsonPropertyName("full_name")] public string? FullName { get; set; }
+
+        [JsonPropertyName("description")] public string? Description { get; set; }
+
+        [JsonPropertyName("icon")] public string? Icon { get; set; }
+
+        [JsonPropertyName("dependencies")] public List<string>? Dependencies { get; set; }
+
+        [JsonPropertyName("download_url")] public string? DownloadUrl { get; set; }
+
+        [JsonPropertyName("downloads")] public int Downloads { get; set; }
+
+        [JsonPropertyName("date_created")] public DateTime DateCreated { get; set; }
+
+        [JsonPropertyName("website_url")] public string? WebsiteUrl { get; set; }
+
+        [JsonPropertyName("is_active")] public bool IsActive { get; set; }
+    }
+
+    [JsonPropertyName("available_communities")]
+    public List<AvailableCommunityData>? AvailableCommunities { get; set; }
+
+    [JsonPropertyName("package_version")] public PackageVersionData? PackageVersion { get; set; }
+}
+
+[JsonSerializable(typeof(PublishData))]
+public partial class PublishDataContext : JsonSerializerContext { }

--- a/ThunderstoreCLI/PackageManifestV1.cs
+++ b/ThunderstoreCLI/PackageManifestV1.cs
@@ -1,9 +1,10 @@
 using System.Text.Json.Serialization;
+using ThunderstoreCLI.Models;
 
 namespace ThunderstoreCLI;
 
 [System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverageAttribute]
-public class PackageManifestV1
+public class PackageManifestV1 : BaseJson<PackageManifestV1, PackageManifestV1Context>
 {
     [JsonPropertyName("namespace")]
     public string? Namespace { get; set; }
@@ -23,3 +24,6 @@ public class PackageManifestV1
     [JsonPropertyName("website_url")]
     public string? WebsiteUrl { get; set; }
 }
+
+[JsonSerializable(typeof(PackageManifestV1))]
+public partial class PackageManifestV1Context : JsonSerializerContext { }


### PR DESCRIPTION
Move to the new with C#10/.NET6 compile-time JSON parsing, should provide a performance improvement for all JSON (de)serialization and removes reflection so the compiler can trim more efficiently.

Verified working by publishing https://thunderstore.dev/package/Windows10CE/tcli_test_package/

Accidentally based this on the history of #43, please merge that one first so I can rebase off master.

closes #37, closes #38 