### PR TITLE
Standardize API Request Building

### DIFF
--- a/ThunderstoreCLI/API/ApiHelper.cs
+++ b/ThunderstoreCLI/API/ApiHelper.cs
@@ -1,0 +1,83 @@
+using System.Net.Http.Headers;
+using System.Text;
+using ThunderstoreCLI.Models;
+using ThunderstoreCLI.Utils;
+
+namespace ThunderstoreCLI.API;
+
+public class ApiHelper
+{
+    private Config.Config Config { get; }
+    private RequestBuilder BaseRequestBuilder { get; }
+
+    private readonly Lazy<AuthenticationHeaderValue> authHeader;
+
+    private AuthenticationHeaderValue AuthHeader => authHeader.Value;
+
+    public ApiHelper(Config.Config config)
+    {
+        Config = config;
+        BaseRequestBuilder = new RequestBuilder(config.PublishConfig.Repository ?? throw new Exception("The target repository cannot be empty"));
+        authHeader = new Lazy<AuthenticationHeaderValue>(() =>
+        {
+            if (string.IsNullOrEmpty(Config.AuthConfig.AuthToken))
+                throw new Exception("This action requires an auth token");
+            return new AuthenticationHeaderValue("Bearer", Config.AuthConfig.AuthToken);
+        });
+    }
+
+    private const string V1 = "api/v1/";
+    private const string EXPERIMENTAL = "api/experimental/";
+
+    public HttpRequestMessage SubmitPackage(string fileUuid)
+    {
+        return BaseRequestBuilder
+            .StartNew()
+            .WithEndpoint(EXPERIMENTAL + "submission/submit/")
+            .WithMethod(HttpMethod.Post)
+            .WithAuth(AuthHeader)
+            .WithContent(new StringContent(Config.GetUploadMetadata(fileUuid).Serialize(), Encoding.UTF8, "application/json"))
+            .GetRequest();
+    }
+
+    public HttpRequestMessage StartUploadMedia(string filePath)
+    {
+        return BaseRequestBuilder
+            .StartNew()
+            .WithEndpoint(EXPERIMENTAL + "usermedia/initiate-upload/")
+            .WithMethod(HttpMethod.Post)
+            .WithAuth(AuthHeader)
+            .WithContent(new StringContent(SerializeFileData(filePath), Encoding.UTF8, "application/json"))
+            .GetRequest();
+    }
+
+    public HttpRequestMessage FinishUploadMedia(CompletedUpload finished, string uuid)
+    {
+        return BaseRequestBuilder
+            .StartNew()
+            .WithEndpoint(EXPERIMENTAL + $"usermedia/{uuid}/finish-upload/")
+            .WithMethod(HttpMethod.Post)
+            .WithAuth(AuthHeader)
+            .WithContent(new StringContent(finished.Serialize(), Encoding.UTF8, "application/json"))
+            .GetRequest();
+    }
+
+    public HttpRequestMessage AbortUploadMedia(string uuid)
+    {
+        return BaseRequestBuilder
+            .StartNew()
+            .WithEndpoint(EXPERIMENTAL + $"usermedia/{uuid}/abort-upload/")
+            .WithMethod(HttpMethod.Post)
+            .WithAuth(AuthHeader)
+            .GetRequest();
+    }
+
+    private static string SerializeFileData(string filePath)
+    {
+        return new FileData()
+        {
+            Filename = Path.GetFileName(filePath),
+            Filesize = new FileInfo(filePath).Length
+        }.Serialize();
+    }
+}

--- a/ThunderstoreCLI/Models/BaseJson.cs
+++ b/ThunderstoreCLI/Models/BaseJson.cs
@@ -1,10 +1,10 @@
+using System.Diagnostics.CodeAnalysis;
 using System.Text.Json;
 using System.Text.Json.Serialization;
-using System.Text.Json.Serialization.Metadata;
 
 namespace ThunderstoreCLI.Models;
 
-public abstract class BaseJson<T, Context>
+public abstract class BaseJson<T, [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicConstructors)] Context>
     where T : BaseJson<T, Context>
     where Context : JsonSerializerContext
 {

--- a/ThunderstoreCLI/Utils/RequestBuilder.cs
+++ b/ThunderstoreCLI/Utils/RequestBuilder.cs
@@ -1,0 +1,64 @@
+using System.Net.Http.Headers;
+
+namespace ThunderstoreCLI.Utils;
+
+public class RequestBuilder
+{
+    private UriBuilder builder { get; } = new()
+    {
+        Scheme = "https"
+    };
+    public HttpMethod Method { get; set; } = HttpMethod.Get;
+    public AuthenticationHeaderValue? AuthHeader { get; set; } = null;
+    public HttpContent? Content { get; set; } = null;
+
+    public RequestBuilder() { }
+
+    public RequestBuilder(string host)
+    {
+        if (host.StartsWith("https://"))
+            host = host[8..];
+        builder.Host = host;
+    }
+
+    public RequestBuilder StartNew()
+    {
+        return new(builder.Uri.Host);
+    }
+
+    public HttpRequestMessage GetRequest()
+    {
+        var req = new HttpRequestMessage(Method, builder.Uri)
+        {
+            Content = Content
+        };
+
+        req.Headers.Authorization = AuthHeader;
+
+        return req;
+    }
+
+    public RequestBuilder WithEndpoint(string endpoint)
+    {
+        builder.Path = endpoint;
+        return this;
+    }
+
+    public RequestBuilder WithAuth(AuthenticationHeaderValue auth)
+    {
+        AuthHeader = auth;
+        return this;
+    }
+
+    public RequestBuilder WithContent(HttpContent content)
+    {
+        Content = content;
+        return this;
+    }
+
+    public RequestBuilder WithMethod(HttpMethod method)
+    {
+        Method = method;
+        return this;
+    }
+}


### PR DESCRIPTION
Moves all building of API requests to a central ApiHelper class contained inside the Config, this was something I made on my own fork before realizing Antti continued my work on this repo.

Open to any changes, mostly opening this to see if this is something we care to have even if it changes quite a bit before being merged.