### PR TITLE
Enable .NET version roll forward

### DIFF
--- a/ThunderstoreCLI/ThunderstoreCLI.csproj
+++ b/ThunderstoreCLI/ThunderstoreCLI.csproj
@@ -3,6 +3,7 @@
     <PropertyGroup>
         <OutputType>Exe</OutputType>
         <TargetFramework>net6.0</TargetFramework>
+        <RollForward>Major</RollForward>
         <LangVersion>preview</LangVersion>
         <EnablePreviewFeatures>true</EnablePreviewFeatures>
         <RootNamespace>ThunderstoreCLI</RootNamespace>


### PR DESCRIPTION
The TCLI dotnet tool won't run on any new .NET 7 installations due to this property existing, and the update to NET 7 is (for some reason, I don't remember why now) included in #64.
This would just allow for TCLI to run on newer installs without complaining until that PR merges.