### PR TITLE
Upgrade to .NET 7

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -2,16 +2,16 @@ name: Publish
 
 on:
   release:
-    types: [released]
+    types: [released, prereleased]
 
 jobs:
   nuget:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
-      - uses: actions/setup-dotnet@v1
+      - uses: actions/setup-dotnet@v3
         with:
-          dotnet-version: '6.0.x'
+          dotnet-version: '7'
 
       - name: Fetch Latest .nupkg
         uses: dsaltares/fetch-gh-release-asset@0efe227dedb360b09ea0e533795d584b61c461a9

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -27,26 +27,26 @@ jobs:
   platform-binary:
     needs: validate-tag
     if: github.event.base_ref == 'refs/heads/master'
-    name: Create binary ${{ matrix.os }}
+    name: Create binary ${{ matrix.target }}
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
         kind: ['linux', 'windows', 'macOS']
         include:
           - kind: linux
-            os: ubuntu-latest
             target: linux-x64
+            os: ubuntu-latest
           - kind: windows
-            os: windows-latest
             target: win-x64
+            os: windows-latest
           - kind: macOS
-            os: macos-latest
             target: osx-x64
+            os: macos-latest
     steps:
       - uses: actions/checkout@v2
-      - uses: actions/setup-dotnet@v1
+      - uses: actions/setup-dotnet@v3
         with:
-          dotnet-version: '6.0.x'
+          dotnet-version: '7'
       - id: tag
         uses: dawidd6/action-get-tag@v1
       - name: Install dependencies
@@ -56,15 +56,15 @@ jobs:
         shell: bash
         run: |
           release_name="tcli-${{ steps.tag.outputs.tag }}-${{ matrix.target }}"
-          dotnet publish ThunderstoreCLI/ThunderstoreCLI.csproj -c Release -r "${{ matrix.target }}" -o "$release_name" -p:PublishReadyToRun=true
+          dotnet publish ThunderstoreCLI/ThunderstoreCLI.csproj -c Release -r "${{ matrix.target }}" -o "${release_name}"
 
           if [ "${{ matrix.target }}" == "win-x64" ]; then
-            7z a -tzip "${release_name}.zip" "./${release_name}/*"
+            7z a -tzip "${release_name}.zip" "./${release_name}"
           else
-            tar czvf "${release_name}.tar.gz" "$release_name"
+            tar czvf "${release_name}.tar.gz" "./${release_name}"
           fi
 
-          rm -r "$release_name"
+          rm -r ${release_name}
 
       - name: Publish to GitHub
         uses: softprops/action-gh-release@v1
@@ -82,9 +82,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
-      - uses: actions/setup-dotnet@v1
+      - uses: actions/setup-dotnet@v3
         with:
-          dotnet-version: '6.0.x'
+          dotnet-version: '7'
       - id: tag
         uses: dawidd6/action-get-tag@v1
       - name: Install dependencies
@@ -92,10 +92,13 @@ jobs:
 
       - name: Build
         shell: bash
-        run: dotnet pack ThunderstoreCLI/ThunderstoreCLI.csproj -c Release -o "." -p:SelfContained=false -p:PublishTrimmed=false -p:PublishSingleFile=false -p:StartupObject="" -p:RuntimeIdentifier="" -p:PublishReadyToRun=false -p:PackAsTool=true
+        run: dotnet pack ThunderstoreCLI/ThunderstoreCLI.csproj -c Release -o "." -p:PublishSelfContained=false -p:PublishSingleFile=false -p:PublishTrimmed=false -p:PublishReadyToRun=false
 
       - name: Publish to GitHub
         uses: softprops/action-gh-release@v1
         with:
           files: "tcli*"
+          name: "Thunderstore CLI ${{ steps.tag.outputs.tag }}"
+          body_path: ${{ github.workspace }}/.github/RELEASE_TEMPLATE.md
           draft: true
+          prerelease: ${{ startsWith(steps.tag.outputs.tag, '0.') }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -56,7 +56,7 @@ jobs:
         shell: bash
         run: |
           release_name="tcli-${{ steps.tag.outputs.tag }}-${{ matrix.target }}"
-          dotnet publish ThunderstoreCLI/ThunderstoreCLI.csproj -c Release -r "${{ matrix.target }}" -o "${release_name}"
+          dotnet publish ThunderstoreCLI/ThunderstoreCLI.csproj -c Release -r "${{ matrix.target }}" -f net7.0 -o "${release_name}"
 
           if [ "${{ matrix.target }}" == "win-x64" ]; then
             7z a -tzip "${release_name}.zip" "./${release_name}"

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -8,9 +8,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
-      - uses: actions/setup-dotnet@v1
+      - uses: actions/setup-dotnet@v3
         with:
-          dotnet-version: '6.0.x'
+          dotnet-version: '7'
       - uses: actions/setup-python@v2
         with:
           python-version: '3.8'
@@ -31,9 +31,9 @@ jobs:
       OS: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@v2
-      - uses: actions/setup-dotnet@v1
+      - uses: actions/setup-dotnet@v3
         with:
-          dotnet-version: '6.0.x'
+          dotnet-version: '7'
       - name: Install dependencies
         run: dotnet restore
       - name: Build

--- a/ThunderstoreCLI.Tests/ThunderstoreCLI.Tests.csproj
+++ b/ThunderstoreCLI.Tests/ThunderstoreCLI.Tests.csproj
@@ -1,7 +1,9 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
     <PropertyGroup>
-        <TargetFramework>net7.0</TargetFramework>
+        <TargetFrameworks>net7.0;net6.0</TargetFrameworks>
+        <RollForward>Major</RollForward>
+        <LangVersion>11</LangVersion>
         <IsPackable>false</IsPackable>
     </PropertyGroup>
 

--- a/ThunderstoreCLI.Tests/ThunderstoreCLI.Tests.csproj
+++ b/ThunderstoreCLI.Tests/ThunderstoreCLI.Tests.csproj
@@ -1,17 +1,14 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
     <PropertyGroup>
-        <TargetFramework>net6.0</TargetFramework>
+        <TargetFramework>net7.0</TargetFramework>
         <IsPackable>false</IsPackable>
-        <RuntimeIdentifier>win-x64</RuntimeIdentifier>
-        <LangVersion>latest</LangVersion>
-        <EnablePreviewFeatures>true</EnablePreviewFeatures>
     </PropertyGroup>
 
     <ItemGroup>
         <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.9.4" />
         <PackageReference Include="Newtonsoft.Json" Version="13.0.1" />
-        <PackageReference Include="Samboy063.Tomlet" Version="3.1.3" />
+        <PackageReference Include="Samboy063.Tomlet" Version="5.0.0" />
         <PackageReference Include="xunit" Version="2.4.1" />
         <PackageReference Include="xunit.runner.visualstudio" Version="2.4.3">
             <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>

--- a/ThunderstoreCLI/Configuration/Config.cs
+++ b/ThunderstoreCLI/Configuration/Config.cs
@@ -1,3 +1,4 @@
+using System.Diagnostics.CodeAnalysis;
 using ThunderstoreCLI.API;
 using ThunderstoreCLI.Models;
 
@@ -128,7 +129,7 @@ public class Config
         return result;
     }
 
-    public static void Merge<T>(T target, T source, bool overwrite)
+    public static void Merge<[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicProperties)] T>(T target, T source, bool overwrite)
     {
         if (source == null)
             return;

--- a/ThunderstoreCLI/Models/BaseJson.cs
+++ b/ThunderstoreCLI/Models/BaseJson.cs
@@ -42,7 +42,7 @@ public static class BaseJson
 
 public static class BaseJsonExtensions
 {
-    public static string SerializeList<T>(this List<T> list, JsonSerializerSettings? options = null)
+    public static string SerializeList<[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.All)] T>(this List<T> list, JsonSerializerSettings? options = null)
         where T : BaseJson<T>
     {
         return JsonConvert.SerializeObject(list, options);

--- a/ThunderstoreCLI/Models/ISerialize.cs
+++ b/ThunderstoreCLI/Models/ISerialize.cs
@@ -6,7 +6,9 @@ public interface ISerialize<[DynamicallyAccessedMembers(DynamicallyAccessedMembe
     where T : ISerialize<T>
 {
     public string Serialize();
+#if NET7_0
     public static abstract T? Deserialize(string input);
     public static abstract ValueTask<T?> DeserializeAsync(string input);
     public static abstract ValueTask<T?> DeserializeAsync(Stream input);
+#endif
 }

--- a/ThunderstoreCLI/Models/Interaction/BaseInteraction.cs
+++ b/ThunderstoreCLI/Models/Interaction/BaseInteraction.cs
@@ -1,3 +1,5 @@
+using System.Diagnostics.CodeAnalysis;
+
 namespace ThunderstoreCLI.Models.Interaction;
 
 public enum InteractionOutputType
@@ -11,7 +13,7 @@ public static class InteractionOptions
     public static InteractionOutputType OutputType { get; set; } = InteractionOutputType.HUMAN;
 }
 
-public abstract class BaseInteraction<T> : BaseJson<T>
+public abstract class BaseInteraction<[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.All)] T> : BaseJson<T>
     where T : BaseInteraction<T>
 {
     public abstract string GetHumanString();

--- a/ThunderstoreCLI/ThunderstoreCLI.csproj
+++ b/ThunderstoreCLI/ThunderstoreCLI.csproj
@@ -2,9 +2,8 @@
 
     <PropertyGroup>
         <OutputType>Exe</OutputType>
-        <TargetFramework>net6.0</TargetFramework>
-        <LangVersion>preview</LangVersion>
-        <EnablePreviewFeatures>true</EnablePreviewFeatures>
+        <TargetFramework>net7.0</TargetFramework>
+        <RollForward>Major</RollForward>
         <RootNamespace>ThunderstoreCLI</RootNamespace>
         <AssemblyName>tcli</AssemblyName>
         <StartupObject>ThunderstoreCLI.Program</StartupObject>
@@ -12,15 +11,15 @@
         <Product>Thunderstore CLI</Product>
         <PackageProjectUrl>https://thunderstore.io/</PackageProjectUrl>
         <Description>Thunderstore CLI is a command-line utility for building and uploading packages to Thunderstore</Description>
-        <RuntimeIdentifier>win-x64</RuntimeIdentifier>
-        <PublishSingleFile>true</PublishSingleFile>
         <PublishTrimmed>true</PublishTrimmed>
-        <SelfContained>true</SelfContained>
+        <TrimMode>partial</TrimMode>
         <PublishReadyToRun>true</PublishReadyToRun>
+        <PublishSingleFile>true</PublishSingleFile>
+        <PublishSelfContained>true</PublishSelfContained>
         <IncludeNativeLibrariesForSelfExtract>true</IncludeNativeLibrariesForSelfExtract>
         <Nullable>enable</Nullable>
         <DebugType Condition=" '$(Configuration)' == 'Release' ">None</DebugType>
-        <LangVersion>latest</LangVersion>
+        <PackAsTool>true</PackAsTool>
         <ToolCommandName>$(AssemblyName)</ToolCommandName>
         <ImplicitUsings>enable</ImplicitUsings>
     </PropertyGroup>
@@ -33,7 +32,7 @@
           <PrivateAssets>all</PrivateAssets>
         </PackageReference>
         <PackageReference Include="Newtonsoft.Json" Version="13.0.1" />
-        <PackageReference Include="Samboy063.Tomlet" Version="3.1.3" />
+        <PackageReference Include="Samboy063.Tomlet" Version="5.0.0" />
     </ItemGroup>
 
     <!-- https://github.com/dotnet/runtime/blob/main/docs/design/features/globalization-invariant-mode.md -->

--- a/ThunderstoreCLI/ThunderstoreCLI.csproj
+++ b/ThunderstoreCLI/ThunderstoreCLI.csproj
@@ -2,7 +2,8 @@
 
     <PropertyGroup>
         <OutputType>Exe</OutputType>
-        <TargetFramework>net7.0</TargetFramework>
+        <TargetFrameworks>net7.0;net6.0</TargetFrameworks>
+        <LangVersion>11</LangVersion>
         <RollForward>Major</RollForward>
         <RootNamespace>ThunderstoreCLI</RootNamespace>
         <AssemblyName>tcli</AssemblyName>

--- a/ThunderstoreCLI/Utils/Spinner.cs
+++ b/ThunderstoreCLI/Utils/Spinner.cs
@@ -66,6 +66,7 @@ public class ProgressSpinner
             if (completed == _tasks.Length)
             {
                 Write.Empty();
+                await Task.WhenAll(_tasks);
                 return;
             }
 


### PR DESCRIPTION
Needed to release a new version usable with the .NET 7 SDK. Older .NET 6 SDKs won't be able to use this version, but will  auto resolve to the last version. No behavioral changes, just project file and CI updates.