### PR TITLE
Fix organization issues in default thunderstore.toml

### DIFF
--- a/ThunderstoreCLI/Configuration/ProjectFileConfig.cs
+++ b/ThunderstoreCLI/Configuration/ProjectFileConfig.cs
@@ -41,7 +41,7 @@ internal class ProjectFileConfig : EmptyConfig
             VersionNumber = Project.Package?.VersionNumber,
             ProjectConfigPath = SourcePath,
             Description = Project.Package?.Description,
-            Dependencies = Project.Package?.Dependencies,
+            Dependencies = Project.Package?.Dependencies.Wrapped,
             ContainsNsfwContent = Project.Package?.ContainsNsfwContent,
             WebsiteUrl = Project.Package?.WebsiteUrl
         };


### PR DESCRIPTION
With these changes the default TOML should now appear as:
```toml
[config]
schemaVersion = "0.0.1"

[package]
namespace = "AuthorName"
name = "PackageName"
versionNumber = "0.0.1"
description = "Example mod description"
websiteUrl = "https://thunderstore.io"
containsNsfwContent = false
[package.dependencies]
AuthorName-PackageName = "0.0.1"


[build]
icon = "./icon.png"
readme = "./README.md"
outdir = "./build"

[[build.copy]]
source = "./dist"
target = ""


[publish]
repository = "https://thunderstore.io"
communities = [ "riskofrain2", ]
categories = [ "items", "skills", ]
```
I find the line endings around `package.dependencies` to be odd, will be asking the Tomlet maintainer about it, since what I did here is a bit of a workaround anyway.

Resolves #69 