### PR TITLE
Local / Global / Env Configuration System

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -135,6 +135,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "atomic"
+version = "0.5.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c59bdb34bc650a32731b31bd8f0829cc15d24a708ee31559e0bb34f2bc320cba"
+
+[[package]]
 name = "atty"
 version = "0.2.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -506,6 +512,20 @@ dependencies = [
 ]
 
 [[package]]
+name = "figment"
+version = "0.10.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4547e226f4c9ab860571e070a9034192b3175580ecea38da34fcdb53a018c9a5"
+dependencies = [
+ "atomic",
+ "pear",
+ "serde",
+ "toml",
+ "uncased",
+ "version_check",
+]
+
+[[package]]
 name = "flate2"
 version = "1.0.26"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -862,6 +882,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "inlinable_string"
+version = "0.1.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c8fae54786f62fb2918dcfae3d568594e50eb9b5c25bf04371af6fe7516452fb"
+
+[[package]]
 name = "inout"
 version = "0.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1164,6 +1190,29 @@ dependencies = [
 ]
 
 [[package]]
+name = "pear"
+version = "0.2.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "61a386cd715229d399604b50d1361683fe687066f42d56f54be995bc6868f71c"
+dependencies = [
+ "inlinable_string",
+ "pear_codegen",
+ "yansi",
+]
+
+[[package]]
+name = "pear_codegen"
+version = "0.2.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "da9f0f13dac8069c139e8300a6510e3f4143ecf5259c60b116a9b271b4ca0d54"
+dependencies = [
+ "proc-macro2",
+ "proc-macro2-diagnostics",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "percent-encoding"
 version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1220,6 +1269,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6aeca18b86b413c660b781aa319e4e2648a3e6f9eadc9b47e9038e6fe9f3451b"
 dependencies = [
  "unicode-ident",
+]
+
+[[package]]
+name = "proc-macro2-diagnostics"
+version = "0.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "af066a9c399a26e020ada66a034357a868728e72cd426f3adcd35f80d88d88c8"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+ "version_check",
+ "yansi",
 ]
 
 [[package]]
@@ -1541,6 +1603,7 @@ dependencies = [
  "clap",
  "colored",
  "directories",
+ "figment",
  "futures",
  "futures-util",
  "indicatif",
@@ -1771,6 +1834,15 @@ name = "typenum"
 version = "1.16.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "497961ef93d974e23eb6f433eb5fe1b7930b659f06d12dec6fc44a8f554c0bba"
+
+[[package]]
+name = "uncased"
+version = "0.9.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9b9bc53168a4be7402ab86c3aad243a84dd7381d09be0eddc81280c1da95ca68"
+dependencies = [
+ "version_check",
+]
 
 [[package]]
 name = "unicode-bidi"
@@ -2162,6 +2234,12 @@ checksum = "388c44dc09d76f1536602ead6d325eb532f5c122f17782bd57fb47baeeb767e2"
 dependencies = [
  "lzma-sys",
 ]
+
+[[package]]
+name = "yansi"
+version = "1.0.0-rc"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9ee746ad3851dd3bc40e4a028ab3b00b99278d929e48957bcb2d111874a7e43e"
 
 [[package]]
 name = "zip"

--- a/crates/tcli/Cargo.toml
+++ b/crates/tcli/Cargo.toml
@@ -25,3 +25,4 @@ directories = "5.0.1"
 colored = "2.0.0"
 async-trait = "0.1.68"
 async_zip = { version = "0.0.15", features = ["full"] }
+figment = { version = "0.10.10", features = ["env", "toml"] }

--- a/crates/tcli/src/config.rs
+++ b/crates/tcli/src/config.rs
@@ -1,19 +1,15 @@
 use std::env::{self, VarError};
-use std::fs::{self, File};
-use std::io::Write;
 use std::path::{Path, PathBuf};
 
+use figment::providers::{Env, Format, Serialized, Toml};
 use figment::Figment;
-use figment::providers::{Format, Serialized, Toml, Env};
-
 use serde::{Deserialize, Serialize};
 
-use crate::error::Error;
 use crate::TCLI_HOME;
 
 pub enum Vars {
     HomeDir,
-    PackageCacheDir,
+    AuthKey,
 }
 
 impl Vars {
@@ -24,7 +20,7 @@ impl Vars {
     pub fn as_str(&self) -> &'static str {
         match self {
             Vars::HomeDir => "TCLI_HOME",
-            Vars::PackageCacheDir => "TCLI_PACKAGE_CACHE",
+            Vars::AuthKey => "TCLI_AUTH_KEY",
         }
     }
 }
@@ -45,7 +41,7 @@ impl Default for Config {
 impl Config {
     pub fn load(project_dir: &Path) -> Result<Self, figment::Error> {
         dbg!(project_dir.join("Config.toml"));
-        
+
         Figment::new()
             .merge(Toml::file(TCLI_HOME.join("Config.toml")))
             .merge(Toml::file(project_dir.join("Config.toml")))

--- a/crates/tcli/src/config.rs
+++ b/crates/tcli/src/config.rs
@@ -1,0 +1,56 @@
+use std::env::{self, VarError};
+use std::fs::{self, File};
+use std::io::Write;
+use std::path::{Path, PathBuf};
+
+use figment::Figment;
+use figment::providers::{Format, Serialized, Toml, Env};
+
+use serde::{Deserialize, Serialize};
+
+use crate::error::Error;
+use crate::TCLI_HOME;
+
+pub enum Vars {
+    HomeDir,
+    PackageCacheDir,
+}
+
+impl Vars {
+    pub fn into_var(self) -> Result<String, VarError> {
+        env::var(self.as_str())
+    }
+
+    pub fn as_str(&self) -> &'static str {
+        match self {
+            Vars::HomeDir => "TCLI_HOME",
+            Vars::PackageCacheDir => "TCLI_PACKAGE_CACHE",
+        }
+    }
+}
+
+#[derive(Serialize, Deserialize, Debug)]
+pub struct Config {
+    pub package_cache: PathBuf,
+}
+
+impl Default for Config {
+    fn default() -> Self {
+        Config {
+            package_cache: TCLI_HOME.join("package_cache"),
+        }
+    }
+}
+
+impl Config {
+    pub fn load(project_dir: &Path) -> Result<Self, figment::Error> {
+        dbg!(project_dir.join("Config.toml"));
+        
+        Figment::new()
+            .merge(Toml::file(TCLI_HOME.join("Config.toml")))
+            .merge(Toml::file(project_dir.join("Config.toml")))
+            .merge(Env::prefixed("TCLI_"))
+            .join(Serialized::defaults(Config::default()))
+            .extract()
+    }
+}

--- a/crates/tcli/src/main.rs
+++ b/crates/tcli/src/main.rs
@@ -3,12 +3,17 @@ use std::path::PathBuf;
 
 use clap::Parser;
 use cli::InitSubcommand;
+use config::Config;
 use directories::BaseDirs;
 use once_cell::sync::Lazy;
 use package::resolver::PackageResolver;
 use project::ProjectKind;
 
 use crate::cli::{Args, Commands};
+<<<<<<< Updated upstream
+=======
+use crate::config::Vars;
+>>>>>>> Stashed changes
 use crate::error::Error;
 use crate::project::manifest::ProjectManifest;
 use crate::project::overrides::ProjectOverrides;
@@ -26,7 +31,13 @@ mod util;
 pub static TCLI_HOME: Lazy<PathBuf> = Lazy::new(|| {
     let default_home = BaseDirs::new().unwrap().data_dir().join("tcli");
 
+<<<<<<< Updated upstream
     env::var("TCLI_HOME").map_or_else(|_| default_home, PathBuf::from)
+=======
+    Vars::HomeDir
+        .into_var()
+        .map_or_else(|_| default_home, PathBuf::from)
+>>>>>>> Stashed changes
 });
 
 #[tokio::main]
@@ -109,6 +120,11 @@ async fn main() -> Result<(), Error> {
             project_path,
         } => {
             ts::init_repository("https://thunderstore.io", None);
+
+            let config = Config::load(project_path.parent().unwrap()).unwrap();
+            dbg!(config);
+
+            panic!("");
 
             let reporter = Box::new(IndicatifReporter);
 

--- a/crates/tcli/src/main.rs
+++ b/crates/tcli/src/main.rs
@@ -1,25 +1,21 @@
-use std::env;
 use std::path::PathBuf;
 
 use clap::Parser;
 use cli::InitSubcommand;
-use config::Config;
 use directories::BaseDirs;
 use once_cell::sync::Lazy;
 use package::resolver::PackageResolver;
 use project::ProjectKind;
 
 use crate::cli::{Args, Commands};
-<<<<<<< Updated upstream
-=======
 use crate::config::Vars;
->>>>>>> Stashed changes
 use crate::error::Error;
 use crate::project::manifest::ProjectManifest;
 use crate::project::overrides::ProjectOverrides;
 use crate::ui::reporter::IndicatifReporter;
 
 mod cli;
+mod config;
 mod error;
 mod game;
 mod package;
@@ -31,13 +27,9 @@ mod util;
 pub static TCLI_HOME: Lazy<PathBuf> = Lazy::new(|| {
     let default_home = BaseDirs::new().unwrap().data_dir().join("tcli");
 
-<<<<<<< Updated upstream
-    env::var("TCLI_HOME").map_or_else(|_| default_home, PathBuf::from)
-=======
     Vars::HomeDir
         .into_var()
         .map_or_else(|_| default_home, PathBuf::from)
->>>>>>> Stashed changes
 });
 
 #[tokio::main]
@@ -93,7 +85,7 @@ async fn main() -> Result<(), Error> {
             repository,
             project_path,
         } => {
-            token = token.or_else(|| std::env::var("TCLI_AUTH_TOKEN").ok());
+            token = token.or_else(|| Vars::AuthKey.into_var().ok());
             if token.is_none() {
                 return Err(Error::MissingAuthToken);
             }
@@ -120,11 +112,6 @@ async fn main() -> Result<(), Error> {
             project_path,
         } => {
             ts::init_repository("https://thunderstore.io", None);
-
-            let config = Config::load(project_path.parent().unwrap()).unwrap();
-            dbg!(config);
-
-            panic!("");
 
             let reporter = Box::new(IndicatifReporter);
 


### PR DESCRIPTION
This implementation uses the figment crate to merge together multiple configuration sources into a single `Config` instance.
- `TCLI_HOME/Config.toml`
- `project_dir/Config.toml`
- Environment vars prefixed with `TCLI`

The specific names and paths of the config files need to be finalized. `TCLI_HOME/Config.toml` makes sense to me, but I think that there's an argument to be made for differentiating the project-local config. Maybe `project_dir/.config.toml` instead?