### PR TITLE
Subscribe to 'published' instead

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -2,7 +2,7 @@ name: Publish
 
 on:
   release:
-    types: [released, prereleased]
+    types: [ published ]
 
 jobs:
   nuget:


### PR DESCRIPTION
This has got to be one of the silliest things I've ever seen
https://docs.github.com/en/actions/using-workflows/events-that-trigger-workflows#release
![image](https://github.com/thunderstore-io/thunderstore-cli/assets/28568841/fd4b90d3-11cf-4eac-9455-069d706f7c21)

