### PR TITLE
Strip build metadata from the software version

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -86,7 +86,7 @@ jobs:
           name: "Thunderstore CLI ${{ needs.validate-tag.outputs.tag }}"
           body_path: ${{ github.workspace }}/.github/RELEASE_TEMPLATE.md
           draft: true
-          prerelease: ${{ startsWith(steps.tag.outputs.tag, '0.') }}
+          prerelease: ${{ startsWith(needs.validate-tag.outputs.tag, '0.') }}
 
   nupkg:
     name: Build NuGet Package
@@ -119,4 +119,4 @@ jobs:
           name: "Thunderstore CLI ${{ needs.validate-tag.outputs.tag }}"
           body_path: ${{ github.workspace }}/.github/RELEASE_TEMPLATE.md
           draft: true
-          prerelease: ${{ startsWith(steps.tag.outputs.tag, '0.') }}
+          prerelease: ${{ startsWith(needs.validate-tag.outputs.tag, '0.') }}

--- a/ThunderstoreCLI/Utils/MiscUtils.cs
+++ b/ThunderstoreCLI/Utils/MiscUtils.cs
@@ -23,8 +23,8 @@ public static class MiscUtils
             throw new Exception("Reading app version from assembly failed");
         }
 
-        // Drop possible pre-release cruft ("-alpha.0.1") from the end.
-        var versionParts = version.Split('-')[0].Split('.');
+        // Drop possible pre-release or build metadata cruft ("-alpha.0.1", "+abcde") from the end.
+        var versionParts = version.Split('-', '+')[0].Split('.');
 
         if (versionParts is null || versionParts.Length != 3)
         {


### PR DESCRIPTION
Pre-release metadata in the SemVer was previously being stripped, i.e.

`0.2.2-alpha.1` -> `0.2.2`

But not *build* metadata. That means that with the following SemVer version (with build, but not pre-release metadata):

`0.2.2+adf02906036cfbd946752d58dc620817b135a0ce` 

`tcli` tries to `parseInt` each 'part' of the version, which leads to the following:

```
Unhandled exception. System.FormatException: The input string '2+adf02906036cfbd946752d58dc620817b135a0ce' was not in a correct format.
   at System.Number.ThrowFormatException[TChar](ReadOnlySpan`1 value)
   at System.Int32.Parse(String s)
   at ThunderstoreCLI.Utils.MiscUtils.<>c.<GetCurrentVersion>b__0_0(String part)
   at System.Linq.Enumerable.SelectArrayIterator`2.Fill(ReadOnlySpan`1 source, Span`1 destination, Func`2 func)
   at System.Linq.Enumerable.SelectArrayIterator`2.ToArray()
   at ThunderstoreCLI.Utils.MiscUtils.GetCurrentVersion()
   at ThunderstoreCLI.UpdateChecker.CheckForUpdates()
   at ThunderstoreCLI.UpdateChecker.WriteUpdateNotification(Task`1 checkTask)
   at ThunderstoreCLI.Program.Main(String[] args)
Aborted (core dumped)
```

This PR ensures that build metadata is also stripped before splitting the version into parts. 