### PR TITLE
Update PackageListingV1.cs to fix #103

### DIFF
--- a/ThunderstoreCLI/Models/PackageListingV1.cs
+++ b/ThunderstoreCLI/Models/PackageListingV1.cs
@@ -104,7 +104,7 @@ public class PackageVersionV1
     public string? Uuid4 { get; set; }
 
     [JsonProperty("file_size")]
-    public int FileSize { get; set; }
+    public long FileSize { get; set; }
 
     [JsonIgnore]
     private GroupCollection? _fullNameParts;


### PR DESCRIPTION
This might be all that is needed to fix #103

I did not find any usages of `FileSize` that would break because of this change. 