### PR TITLE
Fix missing first character for files copied from a source directory that ends with /

### DIFF
--- a/ThunderstoreCLI/Commands/BuildCommand.cs
+++ b/ThunderstoreCLI/Commands/BuildCommand.cs
@@ -225,7 +225,7 @@ public static class BuildCommand
 
             foreach (string filename in Directory.EnumerateFiles(basePath, "*.*", SearchOption.AllDirectories))
             {
-                var targetPath = FormatArchivePath($"{destDirectory}{filename[(basePath.Length + 1)..]}");
+                var targetPath = FormatArchivePath($"{destDirectory}{Path.GetRelativePath(basePath, filename)}");
                 plan.AddPlan(targetPath, () => File.ReadAllBytes(filename));
             }
             return true;


### PR DESCRIPTION
If a `sourcePath` "foo/" is provided, `basePath` = "foo/".

Which results in `basePath.Length + 1` being one character past the directory separator.
So for a file, `bar`, in source directory, `foo`, the argument to `FormatArchivePath` is `$"{destDirectory}foo/ar"` instead of the likely intended `$"{destDirectory}foo/bar"`.
