### PR TITLE
Fix actions rate limit

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -4,6 +4,9 @@ on:
   release:
     types: [ published ]
 
+env:
+  GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }} # For setup-rust
+
 jobs:
   nuget:
     name: Publish NuGet Package

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -5,6 +5,9 @@ on:
     tags:
       - '[0-9]+.[0-9]+.[0-9]+'
 
+env:
+  GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }} # For setup-rust
+
 jobs:
   # Validate tag with proper regex since the check above is very limited.
   validate-tag:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -7,6 +7,9 @@ on:
   # Trigger on any pull request
   pull_request:
 
+env:
+  GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }} # For setup-rust
+
 jobs:
   pre-commit:
     name: Code style check


### PR DESCRIPTION
Release.yml's MacOS actions were getting stuck in a 403 loop.  A similar issue was reported [here](https://github.com/moonrepo/setup-rust/issues/22#issuecomment-2286700547) where the fix was said to be setting the github token to avoid hitting an API rate limit.

Allegedly the action might have unstuck itself eventually, but I ended up canceling it regardless before it might have been able to.